### PR TITLE
[#160737580] Make Fields' Backgrounds Solid

### DIFF
--- a/UI/static/admin.css
+++ b/UI/static/admin.css
@@ -64,12 +64,11 @@ img{
     padding: 0px 10px;
 }
 .fields{
-    background-color: aqua;
     padding-bottom: 50px;
     margin-left: 400px;
     margin-right: 200px;
     margin-top: 200px;
-    background-image: url(../static/images/15.jpg);
+    background-color:rgba(0,0,0,0.5);
     background-position: 10%;
 
 }
@@ -115,7 +114,7 @@ img{
   }
 #na{
     margin-top: 10%;
-    color: rgb(2, 54, 2);
+    color: white;
 }
 input{
     width: 100%;

--- a/UI/static/user_pages.css
+++ b/UI/static/user_pages.css
@@ -56,6 +56,7 @@ img{
 }
 
 .options {
+    margin-top: 100px;
     margin-left: 200px;
     padding: 0px 10px;
 }
@@ -83,11 +84,10 @@ table{
     color: white;    
     margin-left: auto;
     margin-right: auto;
-    background-image: url(../static/images/11.jpg);
     background-size: cover;
     background-repeat: no-repeat;
-    opacity: 0.7;
     height: auto;
+    background-color:rgba(0,0,0,0.5);
 }
 
 td{

--- a/UI/templates/order_history.html
+++ b/UI/templates/order_history.html
@@ -22,17 +22,21 @@
             <table>
                 <th>Order</th>
                 <th>Date</th>
+                <th>Status</th>
                 <tr>
                     <td>Jikoni fries</td>
                     <td>1/8/2018</td>
+                    <td>Completed</td>
                 </tr>
                 <tr>
                     <td>Burger</td>
                     <td>28/8/2018</td>
+                    <td>Completed</td>
                 </tr> 
                 <tr>
                     <td>French fries</td>
                     <td>30/8/2018</td>
+                    <td>Completed</td>
                 </tr> 
 
             </table>


### PR DESCRIPTION
#### What this PR does:
This PR makes the fields' background solid.

#### Task description:
*  Make 'add_new_item' field solid
* Make 'edit_order' field solid
* Edit CSS to make the Fields bold.

#### Manual testing:
$ git clone https://github.com/SnyderMbishai/fast_food_fast.git
$ cd fast_food_fast
$ git checkout bg-fix-fields-backgrounds-160737580
Open the containing folder and open files using a browser(preferably chrome).

#### PT story:
#160737580

#### Screenshot:

![screenshot from 2018-09-24 22-11-23](https://user-images.githubusercontent.com/26184510/45975603-5112c700-c04d-11e8-926b-9b30700099b4.png)
![screenshot from 2018-09-24 22-11-07](https://user-images.githubusercontent.com/26184510/45975604-51ab5d80-c04d-11e8-9888-2b0e3f397878.png)
![screenshot from 2018-09-24 22-10-13](https://user-images.githubusercontent.com/26184510/45975970-25dca780-c04e-11e8-95ae-fe7bb5c061df.png)
